### PR TITLE
Fix MD002 First header should be a top level header

### DIFF
--- a/_phases/01.md
+++ b/_phases/01.md
@@ -3,6 +3,8 @@ phase_number: 1
 title: "Phase 1: Orientation"
 ---
 
+# Phase 1: Orientation
+
 The first phase is about creating a solid foundation for buying and using digital products. Capacity-building starts long before there is any specific software project. Product owners should spend time meeting staff members from various departments, hosting Q&A workshops, debunking myths about government procurement, establishing common language (“agile” “DevOps” “exclusionary criteria”), and sharing the basics of agile software development. The goal is to build up your colleagues’ familiarity with three main things: first, with the steps and objectives of legitimate public sector procurement; second, with contemporary software development processes; and third, with effective design research methods.
 
 With a shared foundation, we are ready to begin a specific software process. The next step is to use discovery research methods to understand the challenge or opportunity, define user needs, and develop ideas about potential solutions. The goal is to arrive at a precise problem statement.
@@ -13,7 +15,7 @@ These options should be evaluated in a neutral way, accounting not only for cost
 
 Phase 1 ends with a choice of strategy. Depending on the approach, you will follow one of four paths...
 
-### Paths
+## Paths
 
 1. Buy Software off the shelf
 2. Contract a vendor to build a custom instance of open source software (OSS)

--- a/_phases/02.md
+++ b/_phases/02.md
@@ -3,13 +3,15 @@ phase_number: 1.a
 title: Capacity Building
 ---
 
-### Goals
+# Capacity Building
+
+## Goals
 
 1. To align various departments and facilitate future collaboration.
 2. To share basic knowledge of software procurement and development processes.
 3. To prioritize a new role: the product owner.
 
-### Phases
+## Phases
 
 _Reaching out to individuals and departments:_
 
@@ -37,20 +39,20 @@ Capacity building should happen long before any given procurement starts.
 - Host regular, city-wide workshops about the basics of procurement. Demystify the process. Emphasize the opportunities for acquiring better products and services, simplicity, efficiency, and creativity.
 - Designate a procurement innovation lead (this could be a product owner) who can check in with department heads or business unit leaders and provide targeted assistance.
 
-### Common Challenges
+## Common Challenges
 
 - _Departmental silos._ Software procurement falls between existing business unit siloes (e.g. Legal, IT, Service delivery, Budgeting / Procurement). Who owns a process? Transitioning to cross-departmental protocols and standards requires process change management that is independent of the implicated departments.
 - _Inadequate or obsolete job descriptions._ There is no formal role or job description for a “product owner” – particularly one focused on software – in the public sector.
 - _Insufficient time._ Staff who could learn from and contribute to ongoing conversations about procurement process reform do not have the time to attend workshops and contribute, in addition to their daily job requirements.
 - _Divergent or conflicting departmental agendas._ These cause misalignment in priorities and friction before and during the software procurement and development process.
 
-### Checklist
+## Checklist
 
 1. Regular multi-departmental workshops and supporting materials.
 2. Well-trained product owners.
 3. Basic familiarity with software development methods across the organization.
 
-### References
+## References
 
 [De-risking Guide](https://derisking-guide.18f.gov/state-field-guide/) from 18F of the GSA's Technology Transformation Services
 

--- a/_phases/03.md
+++ b/_phases/03.md
@@ -3,7 +3,9 @@ phase_number: 1.b
 title: Discovery Research & Problem Statement
 ---
 
-### Goals
+# Discovery Research & Problem Statement
+
+## Goals
 
 1. To bring key stakeholders into the procurement process and draw on their expertise.
 2. To manage expectations and get buy-in with internal stakeholders.
@@ -11,7 +13,7 @@ title: Discovery Research & Problem Statement
 4. To define the (actual) problem and state it clearly.
 5. To set goals and key performance indicators for the project.
 
-### Phases
+## Phases
 
 _Doing discovery research:_
 
@@ -56,13 +58,13 @@ The problem statement and KPIs will carry forward the entire process. Everyone i
 
 - Collect the research, user journeys, problem statement, and KPIs into a single document, then underwrite it – have stakeholders literally sign the document.
 
-### Common Challenges
+## Common Challenges
 
 - _Focusing on existing products._ Early stages of the process should adequately define the problem you need to solve. Jumping to solutions may lead to buying something you don’t need, or limit the possibility of innovative, better-than-expected solutions in the long run.
 - _Insufficient or ineffective user research._ Not addressing the end user can result in building something that is incompatible with the day to day nuances of their job.
 - _Lack of resources for discovery research._ Not having adequate time, resources or knowledge for a discovery research phase undermines the entire procurement and development process.
 
-### Takeaways
+## Takeaways
 
 1. Problem statement based on end users.
 2. Detailed KPIs and broad objectives for the project.

--- a/_phases/04.md
+++ b/_phases/04.md
@@ -3,14 +3,16 @@ phase_number: 1.c
 title: Market Research
 ---
 
-### Goals
+# Market Research
+
+## Goals
 
 1. To become familiar with the problem and the landscape of potential solutions.
 2. To engage responsibly with experts, civic tech community, and the vendor pool.
 3. To circulate the problem statement to experts.
 4. To establish internal and external benchmarks.
 
-### Phases
+## Phases
 
 _Scanning the landscape:_
 
@@ -53,18 +55,18 @@ In some cases, there is only one vendor that can deliver the required solution �
 
 - Identify the landscape of vendors who could fulfill the project needs you’ve documented.
 
-### Common Challenges
+## Common Challenges
 
 - _Lack of internal consistency and digital integration._ Most city governments work with a patchwork of systems. That means they need to use, maintain, and modernize legacy systems simultaneously.
 - _Hesitancy to engage directly with vendors._ Civil servants feel that engaging with vendors is dangerous. It isn’t. Get to know the local and international software community. Become familiar with certain companies you respect. Be actively involved and ask questions.
 - _Insufficient communications between cities._ Civil servants rarely engage with peers (adjacent municipalities or ones that have key commonalities). By discussing mutual challenges, you might find existing solutions, receive recommendations, or glean best practices.
 
-### Checklist
+## Checklist
 
 1. Internal and external benchmarks.
 2. Market analysis and report (including a list of available software, vendors, and business models).
 
-### References
+## References
 
 [Building and Buying Custom Software Guide](https://code.gov/agency-compliance/compliance/procurement)
 

--- a/_phases/05.md
+++ b/_phases/05.md
@@ -3,7 +3,9 @@ phase_number: 1.d
 title: Strategic Analysis
 ---
 
-### Goals
+# Strategic Analysis
+
+## Goals
 
 1. Evaluating different approaches (see below) based on cost and outcome.
 2. Understanding total cost of building, buying and owning software.
@@ -18,7 +20,7 @@ During this phase you will choose one of the following approaches:
 4. Open source software customization (city contracts a software development firm to customize and deploy existing open source software)
 5. Off-the-shelf software (city procures existing software under a standard license agreement)
 
-### Phases
+## Phases
 
 _Conducting a total cost of procurement analysis:_
 
@@ -95,7 +97,7 @@ Large software projects should be broken down into smaller pieces. Each should b
 - Consider that individual pieces might use different development strategies (e.g. some OSS and some contracted)
 - In the next step, you will more specifically define and scope these modules.
 
-### Common Challenges
+## Common Challenges
 
 - _Lack of attention to non-commercial solutions._ License fees for off-the-shelf products are predictable, and therefore easy to budget. In-house development is uncertain, but it often means lower cost and a better product in the long term. This requires a shift in capital budgets – which can be politically and organizationally challenging.
 - _Siloed budgeting and ownership._ Products are typically paid for and managed by a single department with its own budget. However, a good software procurement, development process, and ongoing maintenance will draw on several different business units. Furthermore, modular software should (at minimum) be interoperable with systems across the city.
@@ -103,7 +105,7 @@ Large software projects should be broken down into smaller pieces. Each should b
 - _Lack of creative confidence._ There is a myth that civil servants aren’t, or can’t be, creative and can’t design software. This is false! You are the person who is best suited to understand the problem and imagine solutions.
 - _Lack of familiarity with technical possibility._ Civil servants are not well informed about the state of the art (what is technically possible and impossible). Up front capacity building and market analysis should fill this gap.
 
-### Checklist
+## Checklist
 
 1. Strategic analysis of alternatives for addressing the problem statement based on direct and indirect, present and future costs.
 2. Analysis of the cost of building in-house, the cost of procuring a custom-built software, and the cost of implementing OSS (in-house or contracted).
@@ -111,7 +113,7 @@ Large software projects should be broken down into smaller pieces. Each should b
 4. If there are no commercial solutions:
 5. Initial design studio report, in the form of user journeys and/or scenarios.
 
-### References
+## References
 
 [Total Cost of Ownership (TCO)](https://cdn2.hubspot.net/hubfs/2652075/Downloadable_Files/regoUniversity%202018/Functional/TCO%20Best%20Practices%20for%20TCO%20Costing_SVMGT01.pdf) pdf from regoUniveristy 2018
 

--- a/_phases/06.md
+++ b/_phases/06.md
@@ -3,9 +3,11 @@ phase_number: 6
 title: Assign one leader and hold that person accountable
 ---
 
+# Assign one leader and hold that person accountable
+
 There must be a single product owner who has the authority and responsibility to assign tasks and work elements; make business, product, and technical decisions; and be accountable for the success or failure of the overall service. This product owner is ultimately responsible for how well the service meets the needs of its users, which is how a service should be evaluated. The product owner is responsible for ensuring that features are built and managing the feature and bug backlogs.
 
-### Checklist
+## Checklist
 
 1. A product owner has been identified
 2. All stakeholders agree that the product owner has the authority to assign tasks and make decisions about features and technical implementation details
@@ -13,7 +15,7 @@ There must be a single product owner who has the authority and responsibility to
 4. The product owner has a work plan that includes budget estimates and identifies funding sources
 5. The product owner has a strong relationship with the contracting officer
 
-### Key Questions
+## Key Questions
 
 - Who is the product owner?
 - What organizational changes have been made to ensure the product owner has sufficient authority over and support for the project?

--- a/_phases/07.md
+++ b/_phases/07.md
@@ -3,9 +3,11 @@ phase_number: 7
 title: Bring in experienced teams
 ---
 
+# Bring in experienced teams
+
 We need talented people working in government who have experience creating modern digital services. This includes bringing in seasoned product managers, engineers, and designers. When outside help is needed, our teams should work with contracting officers who understand how to evaluate third-party technical competency so our teams can be paired with contractors who are good at both building and delivering effective digital services. The makeup and experience requirements of the team will vary depending on the scope of the project.
 
-### Checklist
+## Checklist
 
 1. Member(s) of the team have experience building popular, high-traffic digital services
 2. Member(s) of the team have experience designing mobile and web applications

--- a/_phases/08.md
+++ b/_phases/08.md
@@ -3,16 +3,18 @@ phase_number: 8
 title: Choose a modern technology stack
 ---
 
+# Choose a modern technology stack
+
 The technology decisions we make need to enable development teams to work efficiently and enable services to scale easily and cost-effectively. Our choices for hosting infrastructure, databases, software frameworks, programming languages and the rest of the technology stack should seek to avoid vendor lock-in and match what successful modern consumer and enterprise software companies would choose today. In particular, digital services teams should consider using open source, cloud-based, and commodity solutions across the technology stack, because of their widespread adoption and support by successful consumer and enterprise technology companies in the private sector.
 
-### Checklist
+## Checklist
 
 1. Choose software frameworks that are commonly used by private-sector companies creating similar services
 2. Whenever possible, ensure that software can be deployed on a variety of commodity hardware types
 3. Ensure that each project has clear, understandable instructions for setting up a local development environment, and that team members can be quickly added or removed from projects
 4. [Consider open source software solutions](https://www.obamawhitehouse.gov/sites/default/files/omb/assets/egov_docs/memotociostechnologyneutrality.pdf) at every layer of the stack
 
-### Key Questions
+## Key Questions
 
 - What is your development stack and why did you choose it?
 - Which databases are you using and why did you choose them?

--- a/_phases/09.md
+++ b/_phases/09.md
@@ -3,9 +3,11 @@ phase_number: 9
 title: Deploy in a flexible hosting environment
 ---
 
+# Deploy in a flexible hosting environment
+
 Our services should be deployed on flexible infrastructure, where resources can be provisioned in real-time to meet spikes in traffic and user demand. Our digital services are crippled when we host them in data centers that market themselves as “cloud hosting” but require us to manage and maintain hardware directly. This outdated practice wastes time, weakens our disaster recovery plans, and results in significantly higher costs.
 
-### Checklist
+## Checklist
 
 1. Resources are provisioned on demand
 2. Resources scale based on real-time user demand
@@ -15,7 +17,7 @@ Our services should be deployed on flexible infrastructure, where resources can 
 6. Static assets are served through a content delivery network
 7. Application is hosted on commodity hardware
 
-### Key Questions
+## Key Questions
 
 - Where is your service hosted?
 - What hardware does your service use to run?

--- a/_phases/10.md
+++ b/_phases/10.md
@@ -3,9 +3,11 @@ phase_number: 10
 title: Automate testing and deployments
 ---
 
+# Automate testing and deployments
+
 Today, developers write automated scripts that can verify thousands of scenarios in minutes and then deploy updated code into production environments multiple times a day. They use automated performance tests which simulate surges in traffic to identify performance bottlenecks. While manual tests and quality assurance are still necessary, automated tests provide consistent and reliable protection against unintentional regressions, and make it possible for developers to confidently release frequent updates to the service.
 
-### Checklist
+## Checklist
 
 1. Create automated tests that verify all user-facing functionality
 2. Create unit and integration tests to verify modules and components
@@ -13,7 +15,7 @@ Today, developers write automated scripts that can verify thousands of scenarios
 4. Perform deployments automatically with deployment scripts, continuous delivery services, or similar techniques
 5. Conduct load and performance tests at regular intervals, including before public launch
 
-### Key Questions
+## Key Questions
 
 - What percentage of the code base is covered by automated tests?
 - How long does it take to build, test, and deploy a typical bug fix?

--- a/_phases/11.md
+++ b/_phases/11.md
@@ -3,11 +3,13 @@ phase_number: 11
 title: Manage security and privacy through reusable processes
 ---
 
+# Manage security and privacy through reusable processes
+
 Our digital services have to protect sensitive information and keep systems secure. This is typically a process of continuous review and improvement which should be built into the development and maintenance of the service. At the start of designing a new service or feature, the team lead should engage the appropriate privacy, security, and legal officer(s) to discuss the type of information collected, how it should be secured, how long it is kept, and how it may be used and shared. The sustained engagement of a privacy specialist helps ensure that personal data is properly managed. In addition, a key process to building a secure service is comprehensively testing and certifying the components in each layer of the technology stack for security vulnerabilities, and then to re-use these same pre-certified components for multiple services.
 
 The following checklist provides a starting point, but teams should work closely with their privacy specialist and security engineer to meet the needs of the specific service.
 
-### Checklist
+## Checklist
 
 1. Contact the appropriate privacy or legal officer of the department or agency to determine whether a System of Records Notice (SORN), Privacy Impact Assessment, or other review should be conducted
 2. Determine, in consultation with a records officer, what data is collected and why, how it is used or shared, how it is stored and secured, and how long it is kept
@@ -16,7 +18,7 @@ The following checklist provides a starting point, but teams should work closely
 5. “Pre-certify” the hosting infrastructure used for the project using FedRAMP
 6. Use deployment scripts to ensure configuration of production environment remains consistent and controllable
 
-### Key Questions
+## Key Questions
 
 - Does the service collect personal information from the user?  How is the user notified of this collection?
 - Does it collect more information than necessary? Could the data be used in ways an average user wouldn't expect?

--- a/_phases/12.md
+++ b/_phases/12.md
@@ -3,9 +3,11 @@ phase_number: 12
 title: Use data to drive decisions
 ---
 
+# Use data to drive decisions
+
 At every stage of a project, we should measure how well our service is working for our users. This includes measuring how well a system performs and how people are interacting with it in real-time. Our teams and agency leadership should carefully watch these metrics to find issues and identify which bug fixes and improvements should be prioritized. Along with monitoring tools, a feedback mechanism should be in place for people to report issues directly.
 
-### Checklist
+## Checklist
 
 1. Monitor system-level resource utilization in real time
 2. Monitor system performance in real-time (e.g. response time, latency, throughput, and error rates)
@@ -16,7 +18,7 @@ At every stage of a project, we should measure how well our service is working f
 7. Publish metrics externally
 8. Use an experimentation tool that supports multivariate testing in production
 
-### Key Questions
+## Key Questions
 
 - What are the key metrics for the service?
 - How have these metrics performed over the life of the service?

--- a/_phases/13.md
+++ b/_phases/13.md
@@ -3,9 +3,11 @@ phase_number: 13
 title: Default to open
 ---
 
+# Default to open
+
 When we collaborate in the open and publish our data publicly, we can improve Government together. By building services more openly and publishing open data, we simplify the public’s access to government services and information, allow the public to contribute easily, and enable reuse by entrepreneurs, nonprofits, other agencies, and the public.
 
-### Checklist
+## Checklist
 
 1. Offer users a mechanism to report bugs and issues, and be responsive to these reports
 2. Provide datasets to the public, in their entirety, through bulk downloads and APIs (application programming interfaces)
@@ -17,7 +19,7 @@ When we collaborate in the open and publish our data publicly, we can improve Go
 8. When appropriate, publish source code of projects or components online
 9. When appropriate, share your development process and progress publicly
 
-### Key Questions
+## Key Questions
 
 - How are you collecting user feedback for bugs and issues?
 - If there is an API, what capabilities does it provide? Is it versioned? Who uses it? How is it documented?

--- a/script/test-markdown.sh
+++ b/script/test-markdown.sh
@@ -6,10 +6,8 @@
 # MD029 Ordered list item prefix: we allow lists to be sequentially numbered
 #
 # Additionally, we have these violations which should be resolved:
-# MD002 First header should be a top level header
 # MD026 Trailing punctuation in header
 #
 bundle exec mdl -r ~MD007,~MD013,~MD029,\
-~MD002,\
 ~MD026,\
 	-i -g '.'


### PR DESCRIPTION
I think we will wish to word-smith on the top-level headings, but I'd like to do that after we have the structure in place.

Looking at the render, we may wish to investigate different styling for the sub-phases, but that's also not part of this patch.

-----
[View rendered _phases/01.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/01.md)
[View rendered _phases/02.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/02.md)
[View rendered _phases/03.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/03.md)
[View rendered _phases/04.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/04.md)
[View rendered _phases/05.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/05.md)
[View rendered _phases/06.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/06.md)
[View rendered _phases/07.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/07.md)
[View rendered _phases/08.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/08.md)
[View rendered _phases/09.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/09.md)
[View rendered _phases/10.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/10.md)
[View rendered _phases/11.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/11.md)
[View rendered _phases/12.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/12.md)
[View rendered _phases/13.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD002/_phases/13.md)