### PR TITLE
Script to generate site as .pdf MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ notes/*
 .sass-cache/*
 .bundle
 vendor/
+*.pdf

--- a/script/pdf.sh
+++ b/script/pdf.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Simply using the index works okay for a proof-of-concept:
+
+weasyprint http://localhost:4000/index.html \
+	process-code-software-procurement.pdf \
+	--presentational-hints
+
+# Having a special-crafted 'print.html' (and possibly print-cover.html) will
+# allow for much better pdf generation than simply looking at the index.html.
+#
+# In the future, we will probably want something that looks more like the
+# Standard for Public Code's files:
+#  https://github.com/publiccodenet/standard/blob/develop/print.html
+#  https://github.com/publiccodenet/standard/blob/develop/print-cover.html
+#
+# Which will require the above command to become two commands:
+#
+# weasyprint http://localhost:4000/print.html \
+#	process-code-software-procurement.pdf \
+#	--presentational-hints
+#
+# weasyprint http://localhost:4000/print-cover.html \
+#	process-code-software-procurement-cover.pdf \
+#	--presentational-hints


### PR DESCRIPTION
While far from perfect, it actually looks okay-ish using the index.html for a Minimum Viable Product.

We can hand-craft a `print.html` like the Standard for Public Code has in order to make something nicer.