### PR TITLE
Fix MD026 Trailing punctuation in header errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome!
+# Welcome
 
 *This process code introduces a digital-native approach to procurement, while maintaining the integrity of a legitimate, fair, transparent and objective process. It is important because it empowers public sector employees to be in control of how their digital tools are designed, purchased and used.*
 
@@ -6,13 +6,13 @@ You are here because you’ve discovered a challenge or an opportunity in the pu
 …Now what?
 Well, you are in the right place.
 
-## Introduction:
+## Introduction
 
 This document is a guide for procuring existing software, building software in-house, or working with a vendor on custom software. It walks through government contracting step-by-step, aligning legitimate public procurement with the cutting edge best practices of software development. It is not an inflexible legal document. Rather, it’s a set of guidelines and best practices, with links to additional resources.
 
 Because every jurisdiction and every software process is unique, no guide can be one-size-fits-all. That’s why we are hosting this online, in a format that can be revised and adapted over time – by you, the expert on the ground. It’s a new way of creating and sharing best practices across the public sector entities – we call it a “process code.”
 
-## What is Process Code:
+## What is Process Code
 
 Every day, civil servants around the world carry out public processes. And as they face increasingly complex issues – challenges like effective COVID response, public WiFi installation, or software procurement – they need new approaches to those existing public processes.
 
@@ -20,7 +20,7 @@ Cities that are using new approaches can learn from each other, adapt what other
 Contribute to this document here.
 Read more about Process Code here.
 
-## Who should use this Process Code:
+## Who should use this Process Code
 
 Several people from different departments should be involved in a software design and procurement process – from legal counsel to IT to the end users themselves – each bringing their own expertise and perspective. This guide is intended for all of them, but each will have a more prominent role in certain phases.
 

--- a/_includes/introduction.md
+++ b/_includes/introduction.md
@@ -1,6 +1,6 @@
 # Process Code for Software Procurement
 
-## Welcome!
+## Welcome
 
 *This process code introduces a digital-native approach to procurement, while maintaining the integrity of a legitimate, fair, transparent and objective process. It is important because it empowers public sector employees to be in control of how their digital tools are designed, purchased and used.*
 
@@ -8,13 +8,13 @@ You are here because you’ve discovered a challenge or an opportunity in the pu
 …Now what?
 Well, you are in the right place.
 
-## Introduction:
+## Introduction
 
 This document is a guide for procuring existing software, building software in-house, or working with a vendor on custom software. It walks through government contracting step-by-step, aligning legitimate public procurement with the cutting edge best practices of software development. It is not an inflexible legal document. Rather, it’s a set of guidelines and best practices, with links to additional resources.
 
 Because every jurisdiction and every software process is unique, no guide can be one-size-fits-all. That’s why we are hosting this online, in a format that can be revised and adapted over time – by you, the expert on the ground. It’s a new way of creating and sharing best practices across the public sector entities – we call it a “process code.”
 
-## What is Process Code:
+## What is Process Code
 
 Every day, civil servants around the world carry out public processes. And as they face increasingly complex issues – challenges like effective COVID response, public WiFi installation, or software procurement – they need new approaches to those existing public processes.
 
@@ -22,7 +22,7 @@ Cities that are using new approaches can learn from each other, adapt what other
 Contribute to this document here.
 Read more about Process Code here.
 
-## Who should use this Process Code:
+## Who should use this Process Code
 
 Several people from different departments should be involved in a software design and procurement process – from legal counsel to IT to the end users themselves – each bringing their own expertise and perspective. This guide is intended for all of them, but each will have a more prominent role in certain phases.
 

--- a/script/test-markdown.sh
+++ b/script/test-markdown.sh
@@ -7,9 +7,7 @@
 #
 # Additionally, we have these violations which should be resolved:
 # MD002 First header should be a top level header
-# MD026 Trailing punctuation in header
 #
 bundle exec mdl -r ~MD007,~MD013,~MD029,\
 ~MD002,\
-~MD026,\
 	-i -g '.'


### PR DESCRIPTION
Removes redundant colons and reduces some over-the-top enthusiasm.

-----
[View rendered README.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD026/README.md)
[View rendered _includes/introduction.md](https://github.com/publiccodenet/process-code-software-procurement/blob/fix-MD026/_includes/introduction.md)